### PR TITLE
Fix problem of GTK application

### DIFF
--- a/MonoRemoteDebugger.SharedLib/Server/MonoDesktopProcess.cs
+++ b/MonoRemoteDebugger.SharedLib/Server/MonoDesktopProcess.cs
@@ -19,7 +19,7 @@ namespace MonoRemoteDebugger.SharedLib.Server
 
             string args = GetProcessArgs();
             ProcessStartInfo procInfo = GetProcessStartInfo(workingDirectory, monoBin);
-            procInfo.Arguments = args + " \"" + _targetExe + "\"";
+            procInfo.Arguments = args + string.Format(" --config \"{0}.config\" \"{0}\"", _targetExe);
 
             _proc = Process.Start(procInfo);
             RaiseProcessStarted();


### PR DESCRIPTION
GTK application can work only with config files. Because mono need to map dll files to .so files